### PR TITLE
upgrade to manticore 6.3.6

### DIFF
--- a/.github/workflows/container-image-buildah.yml
+++ b/.github/workflows/container-image-buildah.yml
@@ -121,7 +121,8 @@ jobs:
             podman run -d --pod-id-file=podid --name=searchd -u 14:0 "${{ steps.build-image.outputs.image-with-tag }}$1"
             sleep 3
             podman logs searchd
-            podman run --pod-id-file=podid --rm --entrypoint "/bin/env" mysql:8 -- mysql -h 127.0.0.1 -P 9306 -e "SELECT * FROM account limit 1;"
+            podman run --pod-id-file=podid --rm --entrypoint "/bin/env" mysql:8 -- mysql -h 127.0.0.1 -P 9306 -e "INSERT INTO backend_api_core (id, name, system_name) VALUES (1 ,'garga', 'kjdshsafd');"
+            podman run --pod-id-file=podid --rm --entrypoint "/bin/env" mysql:8 -- mysql -h 127.0.0.1 -P 9306 -e "SELECT * FROM backend_api_core limit 1;"
             podman rm -f searchd
           }
 

--- a/rpmbuild/SPECS/manticore-tzdata.spec
+++ b/rpmbuild/SPECS/manticore-tzdata.spec
@@ -1,0 +1,20 @@
+Name:           manticore-tzdata
+Release:        1
+Summary:        Direct Manticore into OS tzdata
+
+Requires:       tzdata
+
+BuildArch:      noarch
+
+License:        MIT
+Version:        1.1
+
+%description
+Symlinks OS tzdata of Red Hat Enterprise Linux 9 for Manticore use.
+
+%install
+mkdir -p %{buildroot}/usr/share/manticore
+ln -s ../zoneinfo %{buildroot}/usr/share/manticore/tzdata
+
+%files
+/usr/share/manticore/tzdata


### PR DESCRIPTION
This version requires a tzdata rpm. Upstream it is basically a copy of ubuntu tzdata dir. See https://github.com/manticoresoftware/manticore-tzdata/blob/main/.github/workflows/package.yml

But in our case it is enough to create a minimal RPM with a symlink to the OS/RHEL tzdata directory. No need to keep a copy.